### PR TITLE
Allow ecr:DescibeImages for trusted accounts

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -39,6 +39,7 @@ data "aws_iam_policy_document" "ecr_policy_doc" {
       "ecr:InitiateLayerUpload",
       "ecr:UploadLayerPart",
       "ecr:CompleteLayerUpload",
+      "ecr:DescribeImages",
     ]
   }
 }


### PR DESCRIPTION
To reference a docker image from our service account in the terraform for our environment accounts like this,

```hcl
data "aws_ecr_image" "main_frontend_no" {
  repository_name = "foo"
  registry_id     = local.service_account_id
  image_digest    = data.vy_artifact_version.main_frontend_no.version
}
```

we need to allow `ecr:DescribeImages` from our environment accounts.

We use this to read the commit-sha, that we use for deployment-tracking, from our image tags.