### PR TITLE
Allow ecr:DescribeRepositories from environment accounts

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -40,6 +40,7 @@ data "aws_iam_policy_document" "ecr_policy_doc" {
       "ecr:UploadLayerPart",
       "ecr:CompleteLayerUpload",
       "ecr:DescribeImages",
+      "ecr:DescribeRepositories",
     ]
   }
 }


### PR DESCRIPTION
It appears that we need the `ecr:DescribeRepositories` permission as well. My theory is that we use different versions of the AWS terraform provider that require different permissions. Similar to #1.